### PR TITLE
Upgrade to Paperclip 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,94 +3,83 @@ PATH
   specs:
     neo4jrb-paperclip (0.0.3)
       neo4j (> 3.0.0.alpha.8)
-      paperclip (~> 4.0)
+      paperclip (~> 5.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    actionpack (4.1.8)
-      actionview (= 4.1.8)
-      activesupport (= 4.1.8)
-      rack (~> 1.5.2)
-      rack-test (~> 0.6.2)
-    actionview (4.1.8)
-      activesupport (= 4.1.8)
-      builder (~> 3.1)
-      erubis (~> 2.7.0)
-    active_attr (0.8.4)
-      activemodel (>= 3.0.2, < 4.2)
-      activesupport (>= 3.0.2, < 4.2)
-    activemodel (4.1.8)
-      activesupport (= 4.1.8)
-      builder (~> 3.1)
-    activesupport (4.1.8)
-      i18n (~> 0.6, >= 0.6.9)
-      json (~> 1.7, >= 1.7.7)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    builder (3.2.2)
     climate_control (0.0.3)
       activesupport (>= 3.0)
-    cocaine (0.5.4)
+    cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    erubis (2.7.0)
-    faraday (0.9.0)
+    colored (1.2)
+    concurrent-ruby (1.0.3)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
-      faraday (>= 0.7.4, < 0.10)
-    httparty (0.13.3)
-      json (~> 1.8)
-      multi_xml (>= 0.5.2)
-    httpclient (2.5.3.3)
-    i18n (0.6.11)
-    json (1.8.1)
-    mime-types (2.4.3)
-    minitest (5.4.3)
-    multi_xml (0.5.5)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
+    faraday_middleware-multi_json (0.0.6)
+      faraday_middleware
+      multi_json
+    httpclient (2.8.3)
+    i18n (0.7.0)
+    json (2.0.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mimemagic (0.3.0)
+    minitest (5.10.1)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
-    neo4j (4.0.0.rc.1)
-      active_attr (~> 0.8)
-      activemodel (~> 4)
-      activesupport (~> 4)
-      neo4j-core (~> 3.1.0)
+    neo4j (8.0.1)
+      activemodel (>= 4.0, < 5.1)
+      activesupport (>= 4.0, < 5.1)
+      neo4j-core (>= 7.0.0)
       orm_adapter (~> 0.5.0)
-      railties (~> 4)
-    neo4j-core (3.1.0)
-      activesupport
+    neo4j-core (7.0.2)
+      activesupport (>= 4.0)
       faraday (~> 0.9.0)
-      faraday_middleware (~> 0.9.1)
-      httparty
+      faraday_middleware (~> 0.10.0)
+      faraday_middleware-multi_json
       httpclient
       json
-      net-http-persistent
+      multi_json
+      neo4j-rake_tasks (>= 0.3.0)
+      net-http-persistent (~> 2.9.4)
+    neo4j-rake_tasks (0.7.10)
+      colored
       os
-      zip
+      rake
+      ruby-progressbar
+      rubyzip (>= 1.1.7)
     net-http-persistent (2.9.4)
     orm_adapter (0.5.0)
     os (0.9.6)
-    paperclip (4.2.0)
-      activemodel (>= 3.0.0)
-      activesupport (>= 3.0.0)
-      cocaine (~> 0.5.3)
+    paperclip (5.1.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      cocaine (~> 0.5.5)
       mime-types
-    rack (1.5.2)
-    rack-test (0.6.2)
-      rack (>= 1.0)
-    railties (4.1.8)
-      actionpack (= 4.1.8)
-      activesupport (= 4.1.8)
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
-    rake (10.4.2)
-    thor (0.19.1)
-    thread_safe (0.3.4)
+      mimemagic (~> 0.3.0)
+    rake (12.0.0)
+    ruby-progressbar (1.8.1)
+    rubyzip (1.2.0)
+    thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    zip (2.0.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   neo4jrb-paperclip!
+
+BUNDLED WITH
+   1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     neo4jrb-paperclip (0.0.3)
       neo4j (> 3.0.0.alpha.8)
-      paperclip (~> 5.0)
+      paperclip (>= 4.0)
 
 GEM
   remote: http://rubygems.org/
@@ -20,7 +20,7 @@ GEM
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     colored (1.2)
-    concurrent-ruby (1.0.3)
+    concurrent-ruby (1.0.4)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.1)
@@ -29,12 +29,12 @@ GEM
       faraday_middleware
       multi_json
     httpclient (2.8.3)
-    i18n (0.7.0)
+    i18n (0.8.0)
     json (2.0.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.0)
+    mimemagic (0.3.2)
     minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -82,4 +82,4 @@ DEPENDENCIES
   neo4jrb-paperclip!
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/neo4jrb-paperclip.gemspec
+++ b/neo4jrb-paperclip.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_path  = 'lib'
 
   gem.add_dependency 'neo4j', ['> 3.0.0.alpha.8']
-  gem.add_dependency 'paperclip', ['~> 4.0']
+  gem.add_dependency 'paperclip', ['~> 5.0']
 
 end

--- a/neo4jrb-paperclip.gemspec
+++ b/neo4jrb-paperclip.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_path  = 'lib'
 
   gem.add_dependency 'neo4j', ['> 3.0.0.alpha.8']
-  gem.add_dependency 'paperclip', ['~> 5.0']
+  gem.add_dependency 'paperclip', ['>= 4.0']
 
 end


### PR DESCRIPTION
In our project we're using `aws-sdk` along with `paperclip` (via this gem) and we're looking to upgrade AWS to get rid of the deprecation warning from using Paperclip 4.

```
DEPRECATION WARNING: [paperclip] [deprecation] AWS SDK v1 has been deprecated in paperclip 5. Please consider upgrading to AWS 2 before upgrading paperclip.
```

Because there are breaking changes when upgrading from AWS 1 to 2, and Paperclip 5 is needed to address them, we need to upgrade to Paperclip 5 in this gem.

There are quite a few changes in the `gemfile.lock`, possibly changes you don't want. Just let me know.